### PR TITLE
Add setting to use DDG from url bar only on !,\

### DIFF
--- a/duckduckgo.safariextension/Settings.plist
+++ b/duckduckgo.safariextension/Settings.plist
@@ -9,8 +9,20 @@
 		<string>ddg_locationbar</string>
 		<key>Title</key>
 		<string>DuckDuckGo as default (in Smart Search field)</string>
+		<key>Titles</key>
+		<array>
+  		<string>Yes</string>
+  		<string>No</string>
+  		<string>Only for queries with '!bang' commands or beginning with '\'</string>
+		</array>
 		<key>Type</key>
-		<string>CheckBox</string>
+		<string>RadioButtons</string>
+    <key>Values</key>
+		<array>
+      <true/>
+  		<false/>
+  		<string>bang</string>
+		</array>
 	</dict>
 	<dict>
 		<key>DefaultValue</key>

--- a/duckduckgo.safariextension/html/global.html
+++ b/duckduckgo.safariextension/html/global.html
@@ -222,6 +222,10 @@
           }
 
           var query = evt.query;
+          if ((safari.extension.settings.ddg_locationbar=="bang") && !(/((^|\s)![^\s])|(^\s*\\)/.test(query))) {
+            return;
+          }
+
           if (!checkURL(query)) {
             evt.preventDefault();
             if (safari.extension.settings.dev) console.log('query:', query);

--- a/duckduckgo.safariextension/html/global.html
+++ b/duckduckgo.safariextension/html/global.html
@@ -222,7 +222,7 @@
           }
 
           var query = evt.query;
-          if ((safari.extension.settings.ddg_locationbar=="bang") && !(/((^|\s)![^\s])|(^\s*\\)/.test(query))) {
+          if ((safari.extension.settings.ddg_locationbar=="bang") && !(/(![a-zA-Z0-9\/\.\@\$])|(^\s*\\)/.test(query))) {
             return;
           }
 

--- a/duckduckgo.safariextension/js/popup.js
+++ b/duckduckgo.safariextension/js/popup.js
@@ -277,8 +277,8 @@ function settings_check() {
     localStorage['zeroclickinfo'] = 'false';
 
   document.getElementById('adv_locationbar').checked =
-    safari.extension.settings.ddg_locationbar;
-  if (safari.extension.settings.ddg_locationbar)
+    (safari.extension.settings.ddg_locationbar === true);
+  if (safari.extension.settings.ddg_locationbar === true)
     localStorage['locationbar'] = 'true';
   else
     localStorage['locationbar'] = 'false';


### PR DESCRIPTION

<img width="551" alt="screen shot 2015-12-25 at 01 48 46" src="https://cloud.githubusercontent.com/assets/359030/12001644/c7ff7f0a-aaa9-11e5-9d65-169e9a62010e.png">
Add new third option for ddg_locationbar setting; sends searches to DDG only if a !command or a leading '\' (feel ducky command) is found in query.