### PR TITLE
update: Deprecate thanks page

### DIFF
--- a/duckduckgo.safariextension/Settings.plist
+++ b/duckduckgo.safariextension/Settings.plist
@@ -72,11 +72,5 @@
 		<key>Type</key>
 		<string>CheckBox</string>
 	</dict>
-	<dict>
-		<key>DefaultValue</key>
-    <string>undefined</string>
-		<key>Key</key>
-		<string>latest_version</string>
-	</dict>
 </array>
 </plist>

--- a/duckduckgo.safariextension/html/global.html
+++ b/duckduckgo.safariextension/html/global.html
@@ -17,60 +17,6 @@
 
     }
 
-    var VersionManager = {
-        majorUpdates: [],
-        addMajorUpdate: function (vers) {
-            this.majorUpdates = this.majorUpdates.concat(vers);
-        },
-        isMajorUpdate: function (ver) {
-            return (this.majorUpdates.indexOf(ver) != -1);
-        }
-    };
-
-    VersionManager.addMajorUpdate('1.6.5');
-
-    console.log(safari.extension.displayVersion, localStorage['last_version'],
-                safari.extension.settings.latest_version);
-
-    if (safari.extension.displayVersion != safari.extension.settings.latest_version) {
-      // following the updatepage setting
-      if (safari.extension.settings.updatepage) {
-
-        if ((typeof localStorage['last_version'] == "undefined") &&
-            (safari.extension.settings.latest_version == "undefined")) {
-
-          console.log('new install, opening install page');
-
-          openTab(THANKS_URL + '?to=' + safari.extension.displayVersion);
-
-        } else {
-          var path = '?from=' + localStorage['last_version'] +
-                     '&to=' + safari.extension.displayVersion;
-
-          console.log('seems to be an update, checking if it is a major one');
-
-          // A hacky way of preserving a setting whose default has changed.
-          if ((safari.extension.settings.latest_version === '1.6.5') &&
-              (safari.extension.displayVersion == '1.6.7')) {
-            safari.extension.settings.zeroclickinfo = (localStorage['zeroclickinfo'] === 'true');
-            console.log('set zeroclickinfo to', safari.extension.settings.zeroclickinfo);
-          }
-
-          // show update page if the current version is considered a major update
-          if (VersionManager.isMajorUpdate(safari.extension.displayVersion)) {
-            console.log('major update, opening update page');
-            openTab(THANKS_URL + path);
-          }
-        }
-
-      }
-
-      localStorage['last_version'] = safari.extension.displayVersion;
-      safari.extension.settings.latest_version = safari.extension.displayVersion;
-    }
-
-
-
     function ddgRightClickCommand(event) {
         if (!safari.extension.settings.rightclick) {
          return;


### PR DESCRIPTION
* Do not show the thanks page on install or update.

* Remove setting that allowed users to choose whether they wanted to see
  the thanks page or not.

Signed-off-by: mr.Shu <mr@shu.io>