### PR TITLE
Changed 'Ask Dax' to 'Search DuckDuckGo' (fixes #24)

### DIFF
--- a/duckduckgo.safariextension/Info.plist
+++ b/duckduckgo.safariextension/Info.plist
@@ -26,7 +26,7 @@
 				<key>Identifier</key>
 				<string>ddg_context</string>
 				<key>Title</key>
-				<string>Ask Dax</string>
+				<string>Search DuckDuckGo</string>
 			</dict>
 		</array>
 		<key>Global Page</key>

--- a/duckduckgo.safariextension/html/global.html
+++ b/duckduckgo.safariextension/html/global.html
@@ -93,9 +93,9 @@
 
 
       if (out[0])
-        event.target.title = 'Ask Dax: ' + truncate(out[0], 40);
+        event.target.title = 'Search DuckDuckGo: ' + truncate(out[0], 40);
       else
-        event.target.title = 'Ask Dax about ' + selectedText ;
+        event.target.title = 'Search DuckDuckGo for ' + selectedText ;
     }
 
 


### PR DESCRIPTION
This should be more understandable for users and is more consistent with our other extensions.

Fixes #24 